### PR TITLE
Fix Android Views calendar height animations

### DIFF
--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -1,6 +1,5 @@
 package com.boswelja.ephemeris.views
 
-import android.animation.LayoutTransition
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
@@ -60,10 +59,6 @@ internal class CalendarPageViewHolder(
 
     private val inflater = LayoutInflater.from(itemView.context)
 
-    init {
-        binding.root.layoutTransition = LayoutTransition()
-    }
-
     fun bindDisplayRows(
         dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
         page: CalendarPage
@@ -73,12 +68,6 @@ internal class CalendarPageViewHolder(
             page.rows.forEach {
                 val row = createPopulatedRow(dayBinder, it)
                 addView(row)
-            }
-            val wMeasureSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY)
-            val hMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-            measure(wMeasureSpec, hMeasureSpec)
-            layoutParams = layoutParams.also {
-                it.height = measuredHeight
             }
         }
     }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteHorizontalPager.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteHorizontalPager.kt
@@ -27,7 +27,7 @@ open class InfiniteHorizontalPager @JvmOverloads constructor(
     open fun onPageSnap(page: Int) { }
 
     override fun onScrollStateChanged(state: Int) {
-        if (state == SCROLL_STATE_IDLE) {
+        if (state == SCROLL_STATE_SETTLING) {
             maybeNotifySnapPositionChange()
         }
     }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteHorizontalPager.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteHorizontalPager.kt
@@ -27,7 +27,7 @@ open class InfiniteHorizontalPager @JvmOverloads constructor(
     open fun onPageSnap(page: Int) { }
 
     override fun onScrollStateChanged(state: Int) {
-        if (state == SCROLL_STATE_SETTLING) {
+        if (state == SCROLL_STATE_IDLE) {
             maybeNotifySnapPositionChange()
         }
     }

--- a/android/views/src/main/res/layout/calendar_page.xml
+++ b/android/views/src/main/res/layout/calendar_page.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical" />

--- a/android/views/src/main/res/values/attrs.xml
+++ b/android/views/src/main/res/values/attrs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <declare-styleable name="EphemerisCalendarView">
-    <attr name="firstDayOfWeek" format="integer" />
-  </declare-styleable>
-</resources>


### PR DESCRIPTION
Height is now correctly animated when changing page sources, as well as scrolling with dynamic row counts