### PR TITLE
Reduce invalidate/requestLayout calls when binding pages

### DIFF
--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -64,7 +64,7 @@ internal class CalendarPageViewHolder(
         page: CalendarPage
     ) {
         binding.root.apply {
-            removeAllViews()
+            removeAllViewsInLayout() // This avoids an extra call to requestLayout and invalidate
             page.rows.forEach {
                 val row = createPopulatedRow(dayBinder, it)
                 addView(row)


### PR DESCRIPTION
By using `removeAllViewsInLayout`, we can avoid an extra call to `invalidate`/`requestLayout` when binding pages.