### PR TITLE
perf(android-views): Avoid inflating views where possible when binding calendar pages

### DIFF
--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -81,13 +81,14 @@ internal class CalendarPageViewHolder(
         binding.root.apply {
             removeAllViewsInLayout() // This avoids an extra call to requestLayout and invalidate
             page.rows.forEachIndexed { index, calendarRow ->
-                val row = createPopulatedRow(calendarRow, index)
+                val row = createPopulatedRow(this, calendarRow, index)
                 addView(row)
             }
         }
     }
 
     private fun createPopulatedRow(
+        parent: ViewGroup,
         row: CalendarRow,
         rowNum: Int
     ): LinearLayout {
@@ -95,7 +96,7 @@ internal class CalendarPageViewHolder(
             // We're recycling a view, make sure it's empty
             root.removeAllViewsInLayout()
         } ?: run {
-            CalendarRowBinding.inflate(inflater, null, false).also {
+            CalendarRowBinding.inflate(inflater, parent, false).also {
                 rowBindingCache.add(rowNum, it)
             }
         }
@@ -107,7 +108,7 @@ internal class CalendarPageViewHolder(
                         LinearLayout.LayoutParams.MATCH_PARENT,
                         LinearLayout.LayoutParams.WRAP_CONTENT
                     ).apply {
-                        weight = 1f
+                        weight = 1f // Ensures a row of date cells will fill the view width
                     }
                 )
             }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -59,14 +59,16 @@ internal class CalendarPageViewHolder(
 
     private val inflater = LayoutInflater.from(itemView.context)
 
+    private val rowBindingCache = mutableListOf<CalendarRowBinding>()
+
     fun bindDisplayRows(
         dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
         page: CalendarPage
     ) {
         binding.root.apply {
             removeAllViewsInLayout() // This avoids an extra call to requestLayout and invalidate
-            page.rows.forEach {
-                val row = createPopulatedRow(dayBinder, it)
+            page.rows.forEachIndexed { index, calendarRow ->
+                val row = createPopulatedRow(dayBinder, calendarRow, index)
                 addView(row)
             }
         }
@@ -74,9 +76,16 @@ internal class CalendarPageViewHolder(
 
     private fun createPopulatedRow(
         dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
-        row: CalendarRow
+        row: CalendarRow,
+        rowNum: Int
     ): LinearLayout {
-        return CalendarRowBinding.inflate(inflater, null, false).root.apply {
+        val binding = rowBindingCache.getOrNull(rowNum) ?: run {
+            CalendarRowBinding.inflate(inflater, null, false).also {
+                rowBindingCache.add(rowNum, it)
+            }
+        }
+        return binding.root.apply {
+            removeAllViewsInLayout()
             row.days.forEach {
                 addView(createDayCell(dayBinder, it))
             }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.boswelja.ephemeris.core.model.CalendarDay
 import com.boswelja.ephemeris.core.model.CalendarPage
 import com.boswelja.ephemeris.core.model.CalendarRow
@@ -25,7 +25,7 @@ internal class CalendarPagerAdapter : InfinitePagerAdapter<CalendarPageViewHolde
             }
         }
 
-    var dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>? = null
+    var dayBinder: CalendarDateBinder<ViewHolder>? = null
         @SuppressLint("NotifyDataSetChanged") // The entire dataset is invalidated when this changes
         set(value) {
             if (value != null && field != value) {
@@ -54,16 +54,17 @@ internal class CalendarPagerAdapter : InfinitePagerAdapter<CalendarPageViewHolde
 
 internal class CalendarPageViewHolder(
     private val binding: CalendarPageBinding
-) : RecyclerView.ViewHolder(binding.root) {
+) : ViewHolder(binding.root) {
 
     private val inflater = LayoutInflater.from(itemView.context)
 
     private val rowBindingCache = mutableListOf<CalendarRowBinding>()
+    private val dateCellViewHolderCache = mutableListOf<ViewHolder>()
 
     private var boundDateCells = 0
 
     fun bindDisplayRows(
-        dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
+        dayBinder: CalendarDateBinder<ViewHolder>,
         page: CalendarPage
     ) {
         boundDateCells = 0
@@ -77,7 +78,7 @@ internal class CalendarPageViewHolder(
     }
 
     private fun createPopulatedRow(
-        dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
+        dayBinder: CalendarDateBinder<ViewHolder>,
         row: CalendarRow,
         rowNum: Int
     ): LinearLayout {
@@ -106,10 +107,14 @@ internal class CalendarPageViewHolder(
 
     private fun createDayCell(
         parent: ViewGroup,
-        dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
+        dayBinder: CalendarDateBinder<ViewHolder>,
         calendarDay: CalendarDay
     ): View {
-        val viewHolder = dayBinder.onCreateViewHolder(inflater, parent)
+        val viewHolder = dateCellViewHolderCache.getOrNull(boundDateCells) ?: run {
+            dayBinder.onCreateViewHolder(inflater, parent).also {
+                dateCellViewHolderCache.add(boundDateCells, it)
+            }
+        }
         dayBinder.onBindView(viewHolder, calendarDay)
         boundDateCells += 1
         return viewHolder.itemView

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -79,13 +79,15 @@ internal class CalendarPageViewHolder(
         row: CalendarRow,
         rowNum: Int
     ): LinearLayout {
-        val binding = rowBindingCache.getOrNull(rowNum) ?: run {
+        val binding = rowBindingCache.getOrNull(rowNum)?.apply {
+            // We're recycling a view, make sure it's empty
+            root.removeAllViewsInLayout()
+        } ?: run {
             CalendarRowBinding.inflate(inflater, null, false).also {
                 rowBindingCache.add(rowNum, it)
             }
         }
         return binding.root.apply {
-            removeAllViewsInLayout()
             row.days.forEach {
                 addView(createDayCell(dayBinder, it))
             }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -48,7 +48,7 @@ internal class CalendarPagerAdapter : InfinitePagerAdapter<CalendarPageViewHolde
 
     override fun onBindHolder(holder: CalendarPageViewHolder, page: Int) {
         val pageState = pageLoader!!.getPageData(page)
-        holder.bindDisplayRows(dayBinder!!, pageState)
+        holder.bindDisplayRows(pageLoader!!, dayBinder!!, pageState)
     }
 }
 
@@ -71,11 +71,21 @@ internal class CalendarPageViewHolder(
                 dateCellViewHolderCache.clear()
             }
         }
+    private var pageLoader: CalendarPageLoader? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                rowBindingCache.clear()
+                dateCellViewHolderCache.clear()
+            }
+        }
 
     fun bindDisplayRows(
+        pageLoader: CalendarPageLoader,
         dayBinder: CalendarDateBinder<ViewHolder>,
         page: CalendarPage
     ) {
+        this.pageLoader = pageLoader
         dateBinder = dayBinder
         boundDateCells = 0
         binding.root.apply {

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -62,6 +62,7 @@ internal class CalendarPageViewHolder(
     private val dateCellViewHolderCache = mutableListOf<ViewHolder>()
 
     private var boundDateCells = 0
+    private var trimDateCellCache = false
 
     private var dateBinder: CalendarDateBinder<ViewHolder>? = null
         set(value) {
@@ -75,8 +76,13 @@ internal class CalendarPageViewHolder(
         set(value) {
             if (field != value) {
                 field = value
-                rowBindingCache.clear()
-                dateCellViewHolderCache.clear()
+                // Only invalidate row cache. date cells are trimmed after binding to optimize CPU
+                rowBindingCache.removeAll {
+                    // Remove all views here to avoid issues when reusing date cells
+                    it.root.removeAllViewsInLayout()
+                    true
+                }
+                trimDateCellCache = true
             }
         }
 
@@ -94,6 +100,11 @@ internal class CalendarPageViewHolder(
                 val row = createPopulatedRow(this, calendarRow, index)
                 addView(row)
             }
+        }
+        if (trimDateCellCache) {
+            trimDateCellCache = false
+            val count = dateCellViewHolderCache.size - boundDateCells - 1
+            if (count > 0) dateCellViewHolderCache.dropLast(count)
         }
     }
 

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -12,7 +12,6 @@ import com.boswelja.ephemeris.core.model.CalendarRow
 import com.boswelja.ephemeris.core.ui.CalendarPageLoader
 import com.boswelja.ephemeris.views.databinding.CalendarPageBinding
 import com.boswelja.ephemeris.views.databinding.CalendarRowBinding
-import com.boswelja.ephemeris.views.databinding.DateCellBinding
 import com.boswelja.ephemeris.views.pager.InfinitePagerAdapter
 
 internal class CalendarPagerAdapter : InfinitePagerAdapter<CalendarPageViewHolder>() {
@@ -61,10 +60,13 @@ internal class CalendarPageViewHolder(
 
     private val rowBindingCache = mutableListOf<CalendarRowBinding>()
 
+    private var boundDateCells = 0
+
     fun bindDisplayRows(
         dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
         page: CalendarPage
     ) {
+        boundDateCells = 0
         binding.root.apply {
             removeAllViewsInLayout() // This avoids an extra call to requestLayout and invalidate
             page.rows.forEachIndexed { index, calendarRow ->
@@ -89,21 +91,28 @@ internal class CalendarPageViewHolder(
         }
         return binding.root.apply {
             row.days.forEach {
-                addView(createDayCell(dayBinder, it))
+                addView(
+                    createDayCell(this, dayBinder, it),
+                    LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.WRAP_CONTENT
+                    ).apply {
+                        weight = 1f
+                    }
+                )
             }
         }
     }
 
     private fun createDayCell(
+        parent: ViewGroup,
         dayBinder: CalendarDateBinder<RecyclerView.ViewHolder>,
         calendarDay: CalendarDay
     ): View {
-        return DateCellBinding.inflate(inflater, binding.root, false).root.apply {
-            // TODO At least try to recycle views
-            val viewHolder = dayBinder.onCreateViewHolder(inflater, this)
-            dayBinder.onBindView(viewHolder, calendarDay)
-            addView(viewHolder.itemView)
-        }
+        val viewHolder = dayBinder.onCreateViewHolder(inflater, parent)
+        dayBinder.onBindView(viewHolder, calendarDay)
+        boundDateCells += 1
+        return viewHolder.itemView
     }
 
     companion object {

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -63,22 +63,31 @@ internal class CalendarPageViewHolder(
 
     private var boundDateCells = 0
 
+    private var dateBinder: CalendarDateBinder<ViewHolder>? = null
+        set(value) {
+            if (field != value) {
+                field = value
+                // Clear our cached date cells on binder change
+                dateCellViewHolderCache.clear()
+            }
+        }
+
     fun bindDisplayRows(
         dayBinder: CalendarDateBinder<ViewHolder>,
         page: CalendarPage
     ) {
+        dateBinder = dayBinder
         boundDateCells = 0
         binding.root.apply {
             removeAllViewsInLayout() // This avoids an extra call to requestLayout and invalidate
             page.rows.forEachIndexed { index, calendarRow ->
-                val row = createPopulatedRow(dayBinder, calendarRow, index)
+                val row = createPopulatedRow(calendarRow, index)
                 addView(row)
             }
         }
     }
 
     private fun createPopulatedRow(
-        dayBinder: CalendarDateBinder<ViewHolder>,
         row: CalendarRow,
         rowNum: Int
     ): LinearLayout {
@@ -93,7 +102,7 @@ internal class CalendarPageViewHolder(
         return binding.root.apply {
             row.days.forEach {
                 addView(
-                    createDayCell(this, dayBinder, it),
+                    createDayCell(this, it),
                     LinearLayout.LayoutParams(
                         LinearLayout.LayoutParams.MATCH_PARENT,
                         LinearLayout.LayoutParams.WRAP_CONTENT
@@ -107,15 +116,14 @@ internal class CalendarPageViewHolder(
 
     private fun createDayCell(
         parent: ViewGroup,
-        dayBinder: CalendarDateBinder<ViewHolder>,
         calendarDay: CalendarDay
     ): View {
         val viewHolder = dateCellViewHolderCache.getOrNull(boundDateCells) ?: run {
-            dayBinder.onCreateViewHolder(inflater, parent).also {
+            dateBinder!!.onCreateViewHolder(inflater, parent).also {
                 dateCellViewHolderCache.add(boundDateCells, it)
             }
         }
-        dayBinder.onBindView(viewHolder, calendarDay)
+        dateBinder!!.onBindView(viewHolder, calendarDay)
         boundDateCells += 1
         return viewHolder.itemView
     }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteAnimatingPager.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfiniteAnimatingPager.kt
@@ -1,5 +1,7 @@
 package com.boswelja.ephemeris.views.pager
 
+import android.animation.Animator
+import android.animation.Animator.AnimatorListener
 import android.animation.LayoutTransition
 import android.animation.ValueAnimator
 import android.content.Context
@@ -91,13 +93,43 @@ internal class PageChangeAnimator(
     ): Boolean {
         val fromHeight = preInfo.bottom - preInfo.top
         val toHeight = postInfo.bottom - preInfo.top
-        heightAnimator.setIntValues(fromHeight, toHeight)
-        heightAnimator.addUpdateListener { animator ->
-            newHolder.itemView.layoutParams = newHolder.itemView.layoutParams.also {
-                it.height = animator.animatedValue as Int
+        if (fromHeight != toHeight) {
+            heightAnimator.setIntValues(fromHeight, toHeight)
+            heightAnimator.addUpdateListener { animator ->
+                newHolder.itemView.layoutParams = newHolder.itemView.layoutParams.also {
+                    it.height = animator.animatedValue as Int
+                }
             }
+            heightAnimator.addListener(
+                object : AnimatorListener {
+                    override fun onAnimationStart(p0: Animator?) {
+                        // No-op
+                    }
+                    override fun onAnimationRepeat(p0: Animator?) {
+                        // No-op
+                    }
+
+                    override fun onAnimationEnd(p0: Animator?) {
+                        heightAnimator.removeAllListeners()
+                        heightAnimator.removeAllUpdateListeners()
+                        dispatchAnimationFinished(oldHolder)
+                        if (oldHolder != newHolder) dispatchAnimationFinished(newHolder)
+                    }
+
+                    override fun onAnimationCancel(p0: Animator?) {
+                        heightAnimator.removeAllListeners()
+                        heightAnimator.removeAllUpdateListeners()
+                        dispatchAnimationFinished(oldHolder)
+                        if (oldHolder != newHolder) dispatchAnimationFinished(newHolder)
+                    }
+
+                }
+            )
+            heightAnimator.start()
+        } else {
+            dispatchAnimationFinished(oldHolder)
+            if (oldHolder != newHolder) dispatchAnimationFinished(newHolder)
         }
-        heightAnimator.start()
         return false
     }
 }

--- a/android/views/src/main/res/layout/date_cell.xml
+++ b/android/views/src/main/res/layout/date_cell.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="1"/>


### PR DESCRIPTION
View inflation is expensive, we should try to avoid that when binding