### PR TITLE
test: Check UI tests as part of CI

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Build
         run: bash ./gradlew assemble
 
-  test:
-    name: Testing
+  unit-test:
+    name: Unit Tests
     runs-on: macos-latest
     needs: assemble
     steps:
@@ -44,15 +44,24 @@ jobs:
       - name: Unit tests
         run: bash ./gradlew test
 
-      - uses: actions/upload-artifact@v2.3.1
-        if: failure()
-        with:
-          name: Unit test results
-          path: ./**/build/reports/tests/
-          if-no-files-found: ignore
-
       - name: Code Coverage
         run: bash ./gradlew koverVerify
+
+  ui-test:
+    name: UI Tests
+    runs-on: macos-latest
+    needs: assemble
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11
+          cache: 'gradle'
+
+      - name: UI tests
+        run: bash ./gradlew pixel4api31Check
 
   code-quality:
     name: Code Quality

--- a/android/views/build.gradle.kts
+++ b/android/views/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     kotlin("android")
     id("com.ephemeris.library.android")
@@ -8,6 +10,18 @@ plugins {
 android {
     namespace = "com.boswelja.ephemeris.views"
     buildFeatures.viewBinding = true
+
+    testOptions {
+        managedDevices {
+            devices {
+                create<ManagedVirtualDevice>("pixel4api31") {
+                    device = "Pixel 4"
+                    apiLevel = 31
+                    systemImageSource = "aosp"
+                }
+            }
+        }
+    }
 
     publishing {
         singleVariant("release") {


### PR DESCRIPTION
This sets up Gradle-managed virtual devices to run Android UI tests as part of our CI flow