### PR TITLE
fix(android-views): notifyDateRangeChanged causes ANR

### DIFF
--- a/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewItemChangeTest.kt
+++ b/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewItemChangeTest.kt
@@ -1,0 +1,102 @@
+package com.boswelja.ephemeris.views
+
+import android.graphics.Color
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso.onIdle
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.boswelja.ephemeris.core.data.CalendarMonthPageSource
+import com.boswelja.ephemeris.core.data.CalendarPageSource
+import com.boswelja.ephemeris.core.datetime.yearMonth
+import com.boswelja.ephemeris.views.CustomViewMatchers.hasChild
+import com.boswelja.ephemeris.views.CustomViewMatchers.withBackgroundColor
+import com.boswelja.ephemeris.views.datebinders.ChangeableDateBinder
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
+import org.hamcrest.Matchers.allOf
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.DayOfWeek
+import kotlin.properties.Delegates
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class EphemerisCalendarViewItemChangeTest {
+
+    private var backgroundColor by Delegates.notNull<Int>()
+
+    @Before
+    fun setUp() {
+        backgroundColor = Color.RED
+    }
+
+    @Test
+    fun notifyDateChanged_correctlyReBindsCell() {
+        val startDate = LocalDate(2022, 4, 19)
+        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
+        scenario.initAndGetCalendarView(
+            pageSource = CalendarMonthPageSource(
+                firstDayOfWeek = DayOfWeek.SUNDAY,
+                startYearMonth = startDate.yearMonth
+            )
+        )
+
+        onIdle()
+
+        backgroundColor = Color.GREEN
+        scenario.onFragment {
+            it.calendarView.notifyDateChanged(startDate)
+        }
+        Thread.sleep(300)
+
+        onView(allOf(isCompletelyDisplayed(), hasChild(withText(startDate.dayOfMonth.toString()))))
+            .check(matches(withBackgroundColor(Color.GREEN)))
+    }
+
+    @Test
+    fun notifyDateRangeChanged_correctlyReBindsCell() {
+        val startDate = LocalDate(2022, 4, 9)
+        val targetRange = startDate..startDate.plus(10, DateTimeUnit.DAY)
+        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
+        scenario.initAndGetCalendarView(
+            pageSource = CalendarMonthPageSource(
+                firstDayOfWeek = DayOfWeek.SUNDAY,
+                startYearMonth = startDate.yearMonth
+            )
+        )
+
+        onIdle()
+
+        backgroundColor = Color.GREEN
+        scenario.onFragment {
+            it.calendarView.notifyDateRangeChanged(targetRange)
+        }
+        Thread.sleep(300)
+
+        onView(allOf(isCompletelyDisplayed(), hasChild(withText(targetRange.start.dayOfMonth.toString()))))
+            .check(matches(withBackgroundColor(Color.GREEN)))
+        onView(allOf(isCompletelyDisplayed(), hasChild(withText(targetRange.endInclusive.dayOfMonth.toString()))))
+            .check(matches(withBackgroundColor(Color.GREEN)))
+    }
+
+    private fun FragmentScenario<EphemerisCalendarFragment>.initAndGetCalendarView(
+        pageSource: CalendarPageSource = CalendarMonthPageSource(DayOfWeek.SUNDAY)
+    ): EphemerisCalendarView {
+        var calendarView: EphemerisCalendarView? = null
+        onFragment {
+            calendarView = it.calendarView
+            calendarView!!.initCalendar(
+                pageSource,
+                ChangeableDateBinder { backgroundColor }
+            )
+        }
+        return calendarView!!
+    }
+}

--- a/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EspressoExt.kt
+++ b/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EspressoExt.kt
@@ -1,6 +1,9 @@
 package com.boswelja.ephemeris.views
 
+import android.graphics.drawable.ColorDrawable
 import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.children
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers
@@ -105,6 +108,37 @@ object CustomViewMatchers {
                     appendText("Checking the matcher on received view: ")
                     appendText("with height=$height")
                 }
+            }
+        }
+    }
+
+    fun withBackgroundColor(color: Int): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description?) {
+                description?.apply {
+                    appendText("Checking the matcher on received view: ")
+                    appendText("with backgroundColor=$color")
+                }
+            }
+
+            override fun matchesSafely(item: View?): Boolean {
+                return (item?.background is ColorDrawable) && (item.background as ColorDrawable).color == color
+            }
+        }
+    }
+
+    fun hasChild(matcher: Matcher<View>): Matcher<View> {
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description?) {
+                description?.apply {
+                    appendText("Checking the matcher on received view: ")
+                    appendText("with any child matching=$matcher")
+                }
+            }
+
+            override fun matchesSafely(item: View?): Boolean {
+                if (item !is ViewGroup) return false
+                return item.children.any { matcher.matches(it) }
             }
         }
     }

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/datebinders/ChangeableDateBinder.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/datebinders/ChangeableDateBinder.kt
@@ -1,0 +1,31 @@
+package com.boswelja.ephemeris.views.datebinders
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.boswelja.ephemeris.core.model.CalendarDay
+import com.boswelja.ephemeris.views.CalendarDateBinder
+import com.boswelja.ephemeris.views.databinding.BasicDateCellBinding
+
+public class ChangeableDateBinder(
+    private val getBackgroundColor: () -> Int
+) : CalendarDateBinder<BasicDateViewHolder> {
+    override fun onCreateViewHolder(
+        inflater: LayoutInflater,
+        parent: ViewGroup
+    ): BasicDateViewHolder {
+        return BasicDateViewHolder(BasicDateCellBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindView(viewHolder: BasicDateViewHolder, calendarDay: CalendarDay) {
+        viewHolder.binding.root.setBackgroundColor(getBackgroundColor())
+        viewHolder.binding.dateText.apply {
+            text = calendarDay.date.dayOfMonth.toString()
+            isEnabled = calendarDay.isFocusedDate
+        }
+    }
+}
+
+public class ChangeableDateViewHolder(
+    public val binding: BasicDateCellBinding
+) : RecyclerView.ViewHolder(binding.root)

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -87,6 +87,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
         _displayedDateRange = MutableStateFlow(
             calendarAdapter.pageLoader!!.getDateRangeFor(currentPage)
         )
+        scrollToPosition(currentPage)
     }
 
     /**
@@ -103,9 +104,10 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     public fun notifyDateRangeChanged(dates: ClosedRange<LocalDate>) {
         val startPage = pageSource.getPageFor(dates.start)
         val endPage = pageSource.getPageFor(dates.endInclusive)
+        val itemsChanged = endPage - startPage + 1
         calendarAdapter.notifyItemRangeChanged(
             pageToPosition(startPage),
-            pageToPosition(endPage)
+            itemsChanged
         )
     }
 


### PR DESCRIPTION
This was because the underlying call to `notifyItemRangeChanged` was incorrect
Closes #66 