### PR TITLE
fix(android-views): Improve exceptions when the calendar view has not been initialized before interaction

### DIFF
--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -155,7 +155,8 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      */
     public fun scrollToDate(date: LocalDate) {
         val page = pageSource.getPageFor(date)
-        currentPager!!.scrollToPosition(page)
+        checkNotNull(currentPager) { GenericCalendarInitException }
+            .scrollToPosition(page)
     }
 
     /**
@@ -163,7 +164,8 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      */
     public fun animateScrollToDate(date: LocalDate) {
         val page = pageSource.getPageFor(date)
-        currentPager!!.smoothScrollToPosition(page)
+        checkNotNull(currentPager) { GenericCalendarInitException }
+            .smoothScrollToPosition(page)
     }
 
     /**

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -76,7 +76,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      * view to redraw itself.
      */
     public var dateBinder: CalendarDateBinder<*>
-        get() = _dateBinder!!
+        get() = requireNotNull(_dateBinder) { MissingDateBinderException }
         set(value) {
             @Suppress("UNCHECKED_CAST")
             _dateBinder = value as CalendarDateBinder<RecyclerView.ViewHolder>
@@ -91,7 +91,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      * will cause the calendar to recreate it's views.
      */
     public var pageSource: CalendarPageSource
-        get() = _pageLoader!!.calendarPageSource
+        get() = requireNotNull(_pageLoader?.calendarPageSource) { MissingPageSourceException }
         set(value) {
             _pageLoader = CalendarPageLoader(
                 coroutineScope,
@@ -126,19 +126,19 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     }
 
     override fun getPaddingStart(): Int {
-        return currentPager!!.paddingStart
+        return requireNotNull(currentPager?.paddingStart) { GenericCalendarInitException }
     }
 
     override fun getPaddingLeft(): Int {
-        return currentPager!!.paddingLeft
+        return requireNotNull(currentPager?.paddingLeft) { GenericCalendarInitException }
     }
 
     override fun getPaddingEnd(): Int {
-        return currentPager!!.paddingEnd
+        return requireNotNull(currentPager?.paddingEnd) { GenericCalendarInitException }
     }
 
     override fun getPaddingRight(): Int {
-        return currentPager!!.paddingRight
+        return requireNotNull(currentPager?.paddingRight) { GenericCalendarInitException }
     }
 
     override fun setClipToPadding(clipToPadding: Boolean) {
@@ -204,7 +204,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
             setOnSnapPositionChangeListener { updateDisplayedDateRange(it) }
         }
         addView(newView)
-        updateDisplayedDateRange(currentPager!!.currentPage)
+        updateDisplayedDateRange(newView.currentPage)
     }
 
     /**
@@ -215,5 +215,11 @@ public class EphemerisCalendarView @JvmOverloads constructor(
         displayedDateRangeChangeListener?.let {
             it(displayedDateRange)
         }
+    }
+
+    private companion object {
+        private const val MissingPageSourceException = "No page source found! Did you forget to set up the calendar?"
+        private const val MissingDateBinderException = "No date binder found! Did you forget to set up the calendar?"
+        private const val GenericCalendarInitException = "Calendar not configured correctly"
     }
 }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -76,7 +76,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      * view to redraw itself.
      */
     public var dateBinder: CalendarDateBinder<*>
-        get() = requireNotNull(_dateBinder) { MissingDateBinderException }
+        get() = checkNotNull(_dateBinder) { MissingDateBinderException }
         set(value) {
             @Suppress("UNCHECKED_CAST")
             _dateBinder = value as CalendarDateBinder<RecyclerView.ViewHolder>
@@ -91,7 +91,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      * will cause the calendar to recreate it's views.
      */
     public var pageSource: CalendarPageSource
-        get() = requireNotNull(_pageLoader?.calendarPageSource) { MissingPageSourceException }
+        get() = checkNotNull(_pageLoader?.calendarPageSource) { MissingPageSourceException }
         set(value) {
             _pageLoader = CalendarPageLoader(
                 coroutineScope,
@@ -126,19 +126,19 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     }
 
     override fun getPaddingStart(): Int {
-        return requireNotNull(currentPager?.paddingStart) { GenericCalendarInitException }
+        return checkNotNull(currentPager?.paddingStart) { GenericCalendarInitException }
     }
 
     override fun getPaddingLeft(): Int {
-        return requireNotNull(currentPager?.paddingLeft) { GenericCalendarInitException }
+        return checkNotNull(currentPager?.paddingLeft) { GenericCalendarInitException }
     }
 
     override fun getPaddingEnd(): Int {
-        return requireNotNull(currentPager?.paddingEnd) { GenericCalendarInitException }
+        return checkNotNull(currentPager?.paddingEnd) { GenericCalendarInitException }
     }
 
     override fun getPaddingRight(): Int {
-        return requireNotNull(currentPager?.paddingRight) { GenericCalendarInitException }
+        return checkNotNull(currentPager?.paddingRight) { GenericCalendarInitException }
     }
 
     override fun setClipToPadding(clipToPadding: Boolean) {

--- a/config/detekt/detekt-base.yml
+++ b/config/detekt/detekt-base.yml
@@ -136,7 +136,7 @@ complexity:
   ReplaceSafeCallChainWithRun:
     active: false
   StringLiteralDuplication:
-    active: false
+    active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     threshold: 3
     ignoreAnnotation: true


### PR DESCRIPTION
Goodbye NullPointerException
Closes #86 