### PR TITLE
fix(android-views): Date cell margin is not applied

### DIFF
--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -99,12 +99,10 @@ internal class CalendarPageViewHolder(
         }
         return binding.root.apply {
             row.days.forEach {
+                val view = createDayCell(this, it)
                 addView(
-                    createDayCell(this, it),
-                    LinearLayout.LayoutParams(
-                        LinearLayout.LayoutParams.MATCH_PARENT,
-                        LinearLayout.LayoutParams.WRAP_CONTENT
-                    ).apply {
+                    view,
+                    (view.layoutParams as LinearLayout.LayoutParams).apply {
                         weight = 1f // Ensures a row of date cells will fill the view width
                     }
                 )


### PR DESCRIPTION
Date cell margins, along with other layout params, should now stick. Note any layout weight you set will still be overridden
Closes #93