### PR TITLE
fix(android-views): notifyDate*Changed re-binds whole pages at a time

### DIFF
--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
@@ -22,7 +22,8 @@ internal class AlternatingHeightPagerAdapter(
         )
     }
 
-    override fun onBindHolder(holder: VaryingHeightViewHolder, page: Int) {
+    override fun onBindViewHolder(holder: VaryingHeightViewHolder, position: Int) {
+        val page = positionToPage(position)
         val color = if (page % 2 == 0) Color.CYAN else Color.MAGENTA
         holder.binding.content.apply {
             setBackgroundColor(color)

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
@@ -18,7 +18,8 @@ internal class BasicInfinitePagerAdapter : InfinitePagerAdapter<ViewHolder>() {
         )
     }
 
-    override fun onBindHolder(holder: ViewHolder, page: Int) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val page = positionToPage(position)
         holder.bind(page)
     }
 }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -180,7 +180,10 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      */
     public fun notifyDateChanged(date: LocalDate) {
         val page = pageSource.getPageFor(date)
-        calendarAdapter.notifyItemChanged(calendarAdapter.pageToPosition(page))
+        calendarAdapter.notifyItemChanged(
+            calendarAdapter.pageToPosition(page),
+            date..date // We pass the dates here as a range for simplicity in the adapter
+        )
     }
 
     /**
@@ -192,7 +195,8 @@ public class EphemerisCalendarView @JvmOverloads constructor(
         val itemsChanged = endPage - startPage + 1
         calendarAdapter.notifyItemRangeChanged(
             calendarAdapter.pageToPosition(startPage),
-            itemsChanged
+            itemsChanged,
+            dates // We pass the date range here so the adapter can choose what to bind and unbind
         )
     }
 

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
@@ -5,17 +5,11 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 
 internal abstract class InfinitePagerAdapter<T: ViewHolder> : Adapter<T>() {
 
-    abstract fun onBindHolder(holder: T, page: Int)
-
     override fun getItemCount(): Int = MAX_PAGES
 
     override fun getItemId(position: Int): Long = position.toLong()
 
-    final override fun onBindViewHolder(holder: T, position: Int) {
-        onBindHolder(holder, positionToPage(position))
-    }
-
-    private fun positionToPage(position: Int): Int {
+    protected fun positionToPage(position: Int): Int {
         return position - (MAX_PAGES / 2)
     }
 

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/model/CalendarPage.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/model/CalendarPage.kt
@@ -1,9 +1,37 @@
 package com.boswelja.ephemeris.core.model
 
+import kotlinx.datetime.LocalDate
+
 /**
  * Contains information about how the calendar should display a page.
  * @param rows A list of [CalendarRow] for the calendar to display.
  */
 public data class CalendarPage internal constructor(
     val rows: List<CalendarRow>
-)
+) {
+    public fun getFlatIndexOf(date: LocalDate): Int {
+        var currIndex = 0
+        rows.forEach { row ->
+            row.days.forEach {
+                if (it.date == date) {
+                    return currIndex
+                }
+                currIndex += 1
+            }
+        }
+        return -1
+    }
+
+    public fun getDateForFlatIndex(index: Int): CalendarDay {
+        var currIndex = 0
+        rows.forEach { row ->
+            row.days.forEach {
+                if (currIndex == index) {
+                    return it
+                }
+                currIndex += 1
+            }
+        }
+        throw IllegalStateException("Index $index does not exist on this page")
+    }
+}

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/model/CalendarPage.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/model/CalendarPage.kt
@@ -9,6 +9,11 @@ import kotlinx.datetime.LocalDate
 public data class CalendarPage internal constructor(
     val rows: List<CalendarRow>
 ) {
+
+    /**
+     * Get the index of the given [date], if this page were to be flattened to a 1d array.
+     * @return -1 if the date was not found on this page, else the index of the date.
+     */
     public fun getFlatIndexOf(date: LocalDate): Int {
         var currIndex = 0
         rows.forEach { row ->
@@ -22,6 +27,10 @@ public data class CalendarPage internal constructor(
         return -1
     }
 
+    /**
+     * Gets the [CalendarDay] at the given flat [index], or the index of the date if this page were
+     * to be flattened to a 1d array. Throws [IllegalStateException] of the index does not exist.
+     */
     public fun getDateForFlatIndex(index: Int): CalendarDay {
         var currIndex = 0
         rows.forEach { row ->

--- a/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/model/CalendarPageTest.kt
+++ b/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/model/CalendarPageTest.kt
@@ -1,0 +1,123 @@
+package com.boswelja.ephemeris.core.model
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class CalendarPageTest {
+
+    @Test
+    fun getFlatIndexOf_returnsCorrectForOutOfBounds() {
+        val page = calendarPage {
+            rows(6) { row ->
+                val startDate = LocalDate(2022, Month.MAY, 8).plus(row, DateTimeUnit.WEEK)
+                days(7) { col ->
+                    date = startDate.plus(col, DateTimeUnit.DAY)
+                    focused = true
+                }
+            }
+        }
+        val firstDate = page.rows.first().days.first()
+        val lastDate = page.rows.last().days.last()
+
+        // Check one before the first date
+        assertEquals(
+            -1,
+            page.getFlatIndexOf(firstDate.date.minus(1, DateTimeUnit.DAY))
+        )
+        // Check one after the last date
+        assertEquals(
+            -1,
+            page.getFlatIndexOf(lastDate.date.plus(1, DateTimeUnit.DAY))
+        )
+    }
+
+    @Test
+    fun getFlatIndexOf_returnsCorrectForInBounds() {
+        val page = calendarPage {
+            rows(6) { row ->
+                val startDate = LocalDate(2022, Month.MAY, 8).plus(row, DateTimeUnit.WEEK)
+                days(7) { col ->
+                    date = startDate.plus(col, DateTimeUnit.DAY)
+                    focused = true
+                }
+            }
+        }
+        val firstDate = page.rows.first().days.first()
+        val lastDate = page.rows.last().days.last()
+
+        // Check first date
+        assertEquals(
+            0,
+            page.getFlatIndexOf(firstDate.date)
+        )
+        // Check last date
+        assertEquals(
+            41,
+            page.getFlatIndexOf(lastDate.date)
+        )
+        // Check arbitrary row
+        assertEquals(
+            7,
+            page.getFlatIndexOf(page.rows[1].days.first().date)
+        )
+    }
+
+    @Test
+    fun getDateForFlatIndex_throwsWhenOutOfBounds() {
+        val page = calendarPage {
+            rows(6) { row ->
+                val startDate = LocalDate(2022, Month.MAY, 8).plus(row, DateTimeUnit.WEEK)
+                days(7) { col ->
+                    date = startDate.plus(col, DateTimeUnit.DAY)
+                    focused = true
+                }
+            }
+        }
+
+        // Check for one before start
+        assertFails {
+            page.getDateForFlatIndex(-1)
+        }
+        // Check for one after end
+        assertFails {
+            page.getDateForFlatIndex(42)
+        }
+    }
+
+    @Test
+    fun getDateForFlatIndex_returnsWhenInBounds() {
+        val page = calendarPage {
+            rows(6) { row ->
+                val startDate = LocalDate(2022, Month.MAY, 8).plus(row, DateTimeUnit.WEEK)
+                days(7) { col ->
+                    date = startDate.plus(col, DateTimeUnit.DAY)
+                    focused = true
+                }
+            }
+        }
+        val firstDate = page.rows.first().days.first()
+        val lastDate = page.rows.last().days.last()
+
+        // Check first date
+        assertEquals(
+            firstDate,
+            page.getDateForFlatIndex(0)
+        )
+        // Check last date
+        assertEquals(
+            lastDate,
+            page.getDateForFlatIndex(41)
+        )
+        // Check arbitrary row
+        assertEquals(
+            page.rows[1].days.first(),
+            page.getDateForFlatIndex(7)
+        )
+    }
+}


### PR DESCRIPTION
Closes #49 
Also removed some redundant logic, and added functionality to the core CalendarPage