### PR TITLE
fix(android-views): Overlapping dates don't get updated when notifyDate*Changed is called

### DIFF
--- a/android/sample/src/main/java/com/boswelja/ephemeris/sample/custompagesource/CustomCalendarPageSource.kt
+++ b/android/sample/src/main/java/com/boswelja/ephemeris/sample/custompagesource/CustomCalendarPageSource.kt
@@ -26,6 +26,8 @@ class CustomCalendarPageSource(
     private val daysInRow = 5
     private val rowCount = 2
 
+    override val hasOverlappingDates: Boolean = false
+
     override fun loadPageData(
         page: Int
     ): CalendarPage {

--- a/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewDateChangeTest.kt
+++ b/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewDateChangeTest.kt
@@ -7,6 +7,7 @@ import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -15,9 +16,11 @@ import com.boswelja.ephemeris.core.data.CalendarPageSource
 import com.boswelja.ephemeris.core.datetime.yearMonth
 import com.boswelja.ephemeris.views.CustomViewMatchers.hasChild
 import com.boswelja.ephemeris.views.CustomViewMatchers.withBackgroundColor
+import com.boswelja.ephemeris.views.EphemerisCalendarViewActions.scrollTo
 import com.boswelja.ephemeris.views.datebinders.ChangeableDateBinder
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
@@ -98,6 +101,63 @@ class EphemerisCalendarViewDateChangeTest {
             .check(matches(withBackgroundColor(Color.RED)))
         onView(allOf(isCompletelyDisplayed(), hasChild(withText((targetRange.endInclusive.dayOfMonth + 1).toString()))))
             .check(matches(withBackgroundColor(Color.RED)))
+    }
+
+    @Test
+    fun notifyDateChange_updatesOverlappingDates() {
+        // Init test
+        val startDate = LocalDate(2022, 5, 31)
+        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
+        scenario.initAndGetCalendarView(
+            pageSource = CalendarMonthPageSource(
+                firstDayOfWeek = DayOfWeek.SUNDAY,
+                startYearMonth = startDate.yearMonth
+            )
+        )
+        onIdle()
+
+        // Update the date cell
+        backgroundColor = Color.GREEN
+        scenario.onFragment {
+            it.calendarView.notifyDateChanged(startDate)
+        }
+        Thread.sleep(300)
+
+        // Scroll to the next page
+        onView(withId(R.id.calendar_view)).perform(scrollTo(startDate.plus(1, DateTimeUnit.WEEK)))
+
+        // Check date cell changed
+        onView(allOf(isCompletelyDisplayed(), hasChild(withText(startDate.dayOfMonth.toString()))))
+            .check(matches(withBackgroundColor(Color.GREEN)))
+    }
+
+    @Test
+    fun notifyDateRangeChange_updatesOverlappingDates() {
+        // Init test
+        val startDate = LocalDate(2022, 5, 31)
+        val targetRange = startDate.minus(10, DateTimeUnit.DAY)..startDate
+        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
+        scenario.initAndGetCalendarView(
+            pageSource = CalendarMonthPageSource(
+                firstDayOfWeek = DayOfWeek.SUNDAY,
+                startYearMonth = startDate.yearMonth
+            )
+        )
+        onIdle()
+
+        // Update the date cells
+        backgroundColor = Color.GREEN
+        scenario.onFragment {
+            it.calendarView.notifyDateRangeChanged(targetRange)
+        }
+        Thread.sleep(300)
+
+        // Scroll to the next page
+        onView(withId(R.id.calendar_view)).perform(scrollTo(startDate.plus(1, DateTimeUnit.WEEK)))
+
+        // Check date cell changed
+        onView(allOf(isCompletelyDisplayed(), hasChild(withText(startDate.dayOfMonth.toString()))))
+            .check(matches(withBackgroundColor(Color.GREEN)))
     }
 
     private fun FragmentScenario<EphemerisCalendarFragment>.initAndGetCalendarView(

--- a/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewDateChangeTest.kt
+++ b/android/views/src/androidTest/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarViewDateChangeTest.kt
@@ -56,29 +56,11 @@ class EphemerisCalendarViewDateChangeTest {
         }
         Thread.sleep(300)
 
+        // Check the date cell changed
         onView(allOf(isCompletelyDisplayed(), hasChild(withText(startDate.dayOfMonth.toString()))))
             .check(matches(withBackgroundColor(Color.GREEN)))
-    }
 
-    @Test
-    fun notifyDateChanged_doesNotRebindExtraCells() {
-        val startDate = LocalDate(2022, 4, 19)
-        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
-        scenario.initAndGetCalendarView(
-            pageSource = CalendarMonthPageSource(
-                firstDayOfWeek = DayOfWeek.SUNDAY,
-                startYearMonth = startDate.yearMonth
-            )
-        )
-
-        onIdle()
-
-        backgroundColor = Color.GREEN
-        scenario.onFragment {
-            it.calendarView.notifyDateChanged(startDate)
-        }
-        Thread.sleep(300)
-
+        // Check the before/after cells did not change
         onView(allOf(isCompletelyDisplayed(), hasChild(withText((startDate.dayOfMonth - 1).toString()))))
             .check(matches(withBackgroundColor(Color.RED)))
         onView(allOf(isCompletelyDisplayed(), hasChild(withText((startDate.dayOfMonth + 1).toString()))))
@@ -86,7 +68,7 @@ class EphemerisCalendarViewDateChangeTest {
     }
 
     @Test
-    fun notifyDateRangeChanged_correctlyReBindsCell() {
+    fun notifyDateRangeChanged_correctlyRebindsCells() {
         val startDate = LocalDate(2022, 4, 9)
         val targetRange = startDate..startDate.plus(10, DateTimeUnit.DAY)
         val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
@@ -105,32 +87,13 @@ class EphemerisCalendarViewDateChangeTest {
         }
         Thread.sleep(300)
 
+        // Check the date cells in range changed
         onView(allOf(isCompletelyDisplayed(), hasChild(withText(targetRange.start.dayOfMonth.toString()))))
             .check(matches(withBackgroundColor(Color.GREEN)))
         onView(allOf(isCompletelyDisplayed(), hasChild(withText(targetRange.endInclusive.dayOfMonth.toString()))))
             .check(matches(withBackgroundColor(Color.GREEN)))
-    }
 
-    @Test
-    fun notifyDateRangeChanged_doesNotRebindExtraCells() {
-        val startDate = LocalDate(2022, 4, 9)
-        val targetRange = startDate..startDate.plus(10, DateTimeUnit.DAY)
-        val scenario = launchFragmentInContainer<EphemerisCalendarFragment>()
-        scenario.initAndGetCalendarView(
-            pageSource = CalendarMonthPageSource(
-                firstDayOfWeek = DayOfWeek.SUNDAY,
-                startYearMonth = startDate.yearMonth
-            )
-        )
-
-        onIdle()
-
-        backgroundColor = Color.GREEN
-        scenario.onFragment {
-            it.calendarView.notifyDateRangeChanged(targetRange)
-        }
-        Thread.sleep(300)
-
+        // Check the date cells before/after did not change
         onView(allOf(isCompletelyDisplayed(), hasChild(withText((targetRange.start.dayOfMonth - 1).toString()))))
             .check(matches(withBackgroundColor(Color.RED)))
         onView(allOf(isCompletelyDisplayed(), hasChild(withText((targetRange.endInclusive.dayOfMonth + 1).toString()))))

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -180,10 +180,15 @@ public class EphemerisCalendarView @JvmOverloads constructor(
      */
     public fun notifyDateChanged(date: LocalDate) {
         val page = pageSource.getPageFor(date)
-        calendarAdapter.notifyItemChanged(
-            calendarAdapter.pageToPosition(page),
-            date..date // We pass the dates here as a range for simplicity in the adapter
-        )
+        val dateRange = date..date
+        val internalPosition = calendarAdapter.pageToPosition(page)
+
+        if (pageSource.hasOverlappingDates) {
+            // Notify surrounding pages if needed
+            calendarAdapter.notifyItemRangeChanged(internalPosition - 1, 3, dateRange)
+        } else {
+            calendarAdapter.notifyItemChanged(internalPosition, dateRange)
+        }
     }
 
     /**
@@ -193,11 +198,20 @@ public class EphemerisCalendarView @JvmOverloads constructor(
         val startPage = pageSource.getPageFor(dates.start)
         val endPage = pageSource.getPageFor(dates.endInclusive)
         val itemsChanged = endPage - startPage + 1
-        calendarAdapter.notifyItemRangeChanged(
-            calendarAdapter.pageToPosition(startPage),
-            itemsChanged,
-            dates // We pass the date range here so the adapter can choose what to bind and unbind
-        )
+        if (pageSource.hasOverlappingDates) {
+            // Notify surrounding pages if needed
+            calendarAdapter.notifyItemRangeChanged(
+                calendarAdapter.pageToPosition(startPage) - 1,
+                itemsChanged + 2,
+                dates // We pass the date range here so the adapter can choose what to bind and unbind
+            )
+        } else {
+            calendarAdapter.notifyItemRangeChanged(
+                calendarAdapter.pageToPosition(startPage),
+                itemsChanged,
+                dates // We pass the date range here so the adapter can choose what to bind and unbind
+            )
+        }
     }
 
     private fun initView() {

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -185,7 +185,12 @@ public class EphemerisCalendarView @JvmOverloads constructor(
 
         if (pageSource.hasOverlappingDates) {
             // Notify surrounding pages if needed
-            calendarAdapter.notifyItemRangeChanged(internalPosition - 1, 3, dateRange)
+            val changedPageCount = 3
+            calendarAdapter.notifyItemRangeChanged(
+                internalPosition - 1,
+                changedPageCount,
+                dateRange
+            )
         } else {
             calendarAdapter.notifyItemChanged(internalPosition, dateRange)
         }

--- a/config/detekt/detekt-base.yml
+++ b/config/detekt/detekt-base.yml
@@ -548,7 +548,7 @@ style:
       - '2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
-    ignoreLocalVariableDeclaration: false
+    ignoreLocalVariableDeclaration: true
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
@@ -29,6 +29,8 @@ public class CalendarMonthPageSource(
     private val daysInWeek = DayOfWeek.values().size
     private val weekends = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
 
+    override val hasOverlappingDates: Boolean = true
+
     override fun loadPageData(page: Int): CalendarPage {
         val month = startYearMonth.plus(page)
         val firstDisplayedDate = month.startDate.startOfWeek(firstDayOfWeek)

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
@@ -11,6 +11,12 @@ import kotlinx.datetime.LocalDate
 public interface CalendarPageSource {
 
     /**
+     * Whether this page source has dates that may overlap from one page to the next. Ephemeris may
+     * use this to determine whether additional updates are necessary when changing a date.
+     */
+    public val hasOverlappingDates: Boolean
+
+    /**
      * Takes a page number and a DisplayDate producer, and returns a set of rows to display in the
      * calendar UI. This should not implement any caching itself, caching is handled by consumers.
      */

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
@@ -26,6 +26,8 @@ public class CalendarWeekPageSource(
     private val daysInWeek = DayOfWeek.values().size
     private val weekends = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
 
+    override val hasOverlappingDates: Boolean = false
+
     override fun loadPageData(
         page: Int
     ): CalendarPage {


### PR DESCRIPTION
For example, if a month view was displayed that supported in/out dates, an update to the 31st of May 2022 would not be represented on the page for June 2022. This has been resolved.
Closes #51 