### PR TITLE
feautre(core): CalendarPageSource can specify a page range limit

### DIFF
--- a/android/compose/src/main/kotlin/com/boswelja/ephemeris/compose/EphemerisCalendarState.kt
+++ b/android/compose/src/main/kotlin/com/boswelja/ephemeris/compose/EphemerisCalendarState.kt
@@ -19,7 +19,7 @@ public abstract class EphemerisCalendarState {
     /**
      * The internal [InfinitePagerState] that [EphemerisCalendar] uses to control its page state.
      */
-    internal abstract val pagerState: InfinitePagerState
+    internal lateinit var pagerState: InfinitePagerState
 
     /**
      * [EphemerisCalendar] provides & updates its page source for use within the calendar state.
@@ -45,12 +45,10 @@ public abstract class EphemerisCalendarState {
 
 /**
  * The default implementation of [EphemerisCalendarState]. This is returned by [rememberCalendarState]
- * @param pagerState The default [CalendarPageSource] to use. This can be changed later.
  * @param coroutineScope A coroutine scope to use for running Calendar-related jobs.
  */
 internal class EphemerisCalendarStateImpl internal constructor(
-    private val coroutineScope: CoroutineScope,
-    override val pagerState: InfinitePagerState
+    private val coroutineScope: CoroutineScope
 ) : EphemerisCalendarState() {
 
     override var displayedDateRange by mutableStateOf(LocalDate(1990, 1, 1)..LocalDate(1990, 1, 1))
@@ -73,9 +71,8 @@ internal class EphemerisCalendarStateImpl internal constructor(
 @Composable
 @Stable
 public fun rememberCalendarState(): EphemerisCalendarState {
-    val pagerState = rememberInfinitePagerState()
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
-    return remember(coroutineScope, pagerState) {
-        EphemerisCalendarStateImpl(coroutineScope, pagerState)
+    return remember(coroutineScope) {
+        EphemerisCalendarStateImpl(coroutineScope)
     }
 }

--- a/android/sample/src/main/java/com/boswelja/ephemeris/sample/custompagesource/CustomCalendarPageSource.kt
+++ b/android/sample/src/main/java/com/boswelja/ephemeris/sample/custompagesource/CustomCalendarPageSource.kt
@@ -28,6 +28,8 @@ class CustomCalendarPageSource(
 
     override val hasOverlappingDates: Boolean = false
 
+    override val maxPageRange: IntRange = -120..600
+
     override fun loadPageData(
         page: Int
     ): CalendarPage {

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
@@ -15,6 +15,8 @@ internal class AlternatingHeightPagerAdapter(
 
     private val differentHeights = heights.size
 
+    override fun getItemCount(): Int = Int.MAX_VALUE
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VaryingHeightViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return VaryingHeightViewHolder(

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/AlternatingHeightPagerAdapter.kt
@@ -15,6 +15,14 @@ internal class AlternatingHeightPagerAdapter(
 
     private val differentHeights = heights.size
 
+    override fun pageToPosition(page: Int): Int {
+        return page + (itemCount / 2)
+    }
+
+    override fun positionToPage(position: Int): Int {
+        return position - (itemCount / 2)
+    }
+
     override fun getItemCount(): Int = Int.MAX_VALUE
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VaryingHeightViewHolder {

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
@@ -7,6 +7,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.boswelja.ephemeris.views.pager.InfinitePagerAdapter
 
 internal class BasicInfinitePagerAdapter : InfinitePagerAdapter<ViewHolder>() {
+
+    override fun getItemCount(): Int = Int.MAX_VALUE
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
             View(parent.context).apply {

--- a/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
+++ b/android/views/src/debug/kotlin/com/boswelja/ephemeris/views/pagingadapters/BasicInfinitePagerAdapter.kt
@@ -8,6 +8,14 @@ import com.boswelja.ephemeris.views.pager.InfinitePagerAdapter
 
 internal class BasicInfinitePagerAdapter : InfinitePagerAdapter<ViewHolder>() {
 
+    override fun pageToPosition(page: Int): Int {
+        return page + (itemCount / 2)
+    }
+
+    override fun positionToPage(position: Int): Int {
+        return position - (itemCount / 2)
+    }
+
     override fun getItemCount(): Int = Int.MAX_VALUE
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -19,6 +19,14 @@ internal class CalendarPagerAdapter(
     private val dateBinder: CalendarDateBinder<ViewHolder>
 ) : InfinitePagerAdapter<CalendarPageViewHolder>() {
 
+    override fun pageToPosition(page: Int): Int {
+        return pageLoader.calendarPageSource.mapPageToInternalPosition(page)
+    }
+
+    override fun positionToPage(position: Int): Int {
+        return pageLoader.calendarPageSource.mapInternalPositionToPage(position)
+    }
+
     override fun getItemCount(): Int = pageLoader.calendarPageSource.maxPageRange.count()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarPageViewHolder {

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -19,6 +19,8 @@ internal class CalendarPagerAdapter(
     private val dateBinder: CalendarDateBinder<ViewHolder>
 ) : InfinitePagerAdapter<CalendarPageViewHolder>() {
 
+    override fun getItemCount(): Int = pageLoader.calendarPageSource.maxPageRange.count()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarPageViewHolder {
         return CalendarPageViewHolder.create(parent)
     }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/HeightAdjustingPager.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/HeightAdjustingPager.kt
@@ -34,7 +34,6 @@ internal class HeightAdjustingPager @JvmOverloads constructor(
         snapHelper.attachToRecyclerView(this)
         // Disable item change animations, otherwise we get a crossfade when changing a page
         (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
-        super.scrollToPosition(pageToPosition(currentPage))
     }
 
     /**
@@ -70,6 +69,11 @@ internal class HeightAdjustingPager @JvmOverloads constructor(
         maybeNotifySnapPositionChange(position)
     }
 
+    override fun setAdapter(adapter: Adapter<*>?) {
+        super.setAdapter(adapter)
+        super.scrollToPosition(pageToPosition(currentPage))
+    }
+
     private fun maybeNotifySnapPositionChange(snapPosition: Int) {
         val snapPositionChanged = currentPage != snapPosition
         if (snapPositionChanged) {
@@ -97,18 +101,14 @@ internal class HeightAdjustingPager @JvmOverloads constructor(
      * Maps a position from the underlying RecyclerView to a pager page.
      */
     private fun positionToPage(position: Int): Int {
-        return position - (MAX_PAGES / 2)
+        return (adapter as InfinitePagerAdapter).positionToPage(position)
     }
 
     /**
      * Maps a pager page to the underlying RecyclerView position
      */
     private fun pageToPosition(page: Int): Int {
-        return page + (Int.MAX_VALUE / 2)
-    }
-
-    private companion object {
-        private const val MAX_PAGES = Int.MAX_VALUE
+        return (adapter as InfinitePagerAdapter).pageToPosition(page)
     }
 }
 

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
@@ -7,18 +7,10 @@ internal abstract class InfinitePagerAdapter<T: ViewHolder> : Adapter<T>() {
 
     override fun getItemId(position: Int): Long = position.toLong()
 
-    protected fun positionToPage(position: Int): Int {
-        return position - (MAX_PAGES / 2)
-    }
+    abstract fun positionToPage(position: Int): Int
 
     /**
      * Maps a pager page to the underlying RecyclerView position
      */
-    internal fun pageToPosition(page: Int): Int {
-        return page + (Int.MAX_VALUE / 2)
-    }
-
-    private companion object {
-        private const val MAX_PAGES = Int.MAX_VALUE
-    }
+    abstract fun pageToPosition(page: Int): Int
 }

--- a/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
+++ b/android/views/src/main/kotlin/com/boswelja/ephemeris/views/pager/InfinitePagerAdapter.kt
@@ -5,8 +5,6 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 
 internal abstract class InfinitePagerAdapter<T: ViewHolder> : Adapter<T>() {
 
-    override fun getItemCount(): Int = MAX_PAGES
-
     override fun getItemId(position: Int): Long = position.toLong()
 
     protected fun positionToPage(position: Int): Int {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,6 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20")
-    implementation("com.android.library:com.android.library.gradle.plugin:7.4.0-alpha01")
+    implementation("com.android.library:com.android.library.gradle.plugin:7.4.0-alpha02")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.6.10")
 }

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
@@ -24,7 +24,8 @@ import kotlinx.datetime.todayAt
 public class CalendarMonthPageSource(
     private val firstDayOfWeek: DayOfWeek,
     private val startYearMonth: YearMonth = Clock.System.todayAt(TimeZone.currentSystemDefault()).yearMonth,
-    private val focusMode: FocusMode = FocusMode.MONTH
+    private val focusMode: FocusMode = FocusMode.MONTH,
+    override val maxPageRange: IntRange = IntRange(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
 ) : CalendarPageSource {
     private val daysInWeek = DayOfWeek.values().size
     private val weekends = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSource.kt
@@ -19,13 +19,14 @@ import kotlinx.datetime.todayAt
 
 /**
  * An implementation of [CalendarPageSource] that loads full months. Total rows are dynamic, and
- * will change from month to month.
+ * will change from month to month. The default range for the calendar is 500 years before and after
+ * the given [startYearMonth], and can be overridden by setting [maxPageRange].
  */
 public class CalendarMonthPageSource(
     private val firstDayOfWeek: DayOfWeek,
     private val startYearMonth: YearMonth = Clock.System.todayAt(TimeZone.currentSystemDefault()).yearMonth,
     private val focusMode: FocusMode = FocusMode.MONTH,
-    override val maxPageRange: IntRange = IntRange(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+    override val maxPageRange: IntRange = IntRange(-6000, 6000)
 ) : CalendarPageSource {
     private val daysInWeek = DayOfWeek.values().size
     private val weekends = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
@@ -17,6 +17,13 @@ public interface CalendarPageSource {
     public val hasOverlappingDates: Boolean
 
     /**
+     * Defines the maximum number of pages to be displayed. Pages are zero-based, therefore negative
+     * values represent pages before the start page, and positive values represent pages after the
+     * start page. Note the total number of pages should not exceed [Int.MAX_VALUE].
+     */
+    public val maxPageRange: IntRange
+
+    /**
      * Takes a page number and a DisplayDate producer, and returns a set of rows to display in the
      * calendar UI. This should not implement any caching itself, caching is handled by consumers.
      */
@@ -28,4 +35,3 @@ public interface CalendarPageSource {
      */
     public fun getPageFor(date: LocalDate): Int
 }
-

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarPageSource.kt
@@ -34,4 +34,20 @@ public interface CalendarPageSource {
      * as no results here are cached.
      */
     public fun getPageFor(date: LocalDate): Int
+
+    /**
+     * Maps the given internal position of a zero-based pager to the page number. Note this is not
+     * necessary if we have a pager that supports negative numbers in the first place.
+     */
+    public fun mapInternalPositionToPage(position: Int): Int {
+        return position + maxPageRange.first
+    }
+
+    /**
+     * Maps the given page number to an internal zero-based position. Note this is not
+     * necessary if we have a pager that supports negative numbers in the first place.
+     */
+    public fun mapPageToInternalPosition(page: Int): Int {
+        return page - maxPageRange.first
+    }
 }

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
@@ -18,7 +18,8 @@ import kotlinx.datetime.todayAt
 public class CalendarWeekPageSource(
     firstDayOfWeek: DayOfWeek,
     startDate: LocalDate = Clock.System.todayAt(TimeZone.currentSystemDefault()),
-    private val focusMode: FocusMode = FocusMode.WEEKDAYS
+    private val focusMode: FocusMode = FocusMode.WEEKDAYS,
+    override val maxPageRange: IntRange = IntRange(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
 ) : CalendarPageSource {
 
     private val startDate = startDate.startOfWeek(firstDayOfWeek)

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
@@ -13,13 +13,15 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.todayAt
 
 /**
- * An implementation of [CalendarPageSource] that loads one week per page.
+ * An implementation of [CalendarPageSource] that loads one week per page. The default range for the
+ * calendar is 500 years before and after the given [startDate], and can be overridden by setting
+ * [maxPageRange].
  */
 public class CalendarWeekPageSource(
     firstDayOfWeek: DayOfWeek,
     startDate: LocalDate = Clock.System.todayAt(TimeZone.currentSystemDefault()),
     private val focusMode: FocusMode = FocusMode.WEEKDAYS,
-    override val maxPageRange: IntRange = IntRange(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+    override val maxPageRange: IntRange = IntRange(-26000, 26000)
 ) : CalendarPageSource {
 
     private val startDate = startDate.startOfWeek(firstDayOfWeek)

--- a/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSourceTest.kt
+++ b/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/data/CalendarMonthPageSourceTest.kt
@@ -114,8 +114,8 @@ class CalendarMonthPageSourceTest {
         val source = CalendarMonthPageSource(
             firstDayOfWeek = DayOfWeek.SUNDAY
         )
-        source.loadPageData(Int.MIN_VALUE)
-        source.loadPageData(Int.MAX_VALUE)
+        source.loadPageData(source.maxPageRange.first)
+        source.loadPageData(source.maxPageRange.last)
         source.loadPageData(0)
     }
 


### PR DESCRIPTION
Users can now restrict the number of pages before and after the start page for their page source.
Closes #43 