### PR TITLE
fix(core): YearMonth for January has the wrong year when scrolling backwards

### DIFF
--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/datetime/YearMonth.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/datetime/YearMonth.kt
@@ -19,16 +19,9 @@ public val LocalDate.yearMonth: YearMonth
     get() = YearMonth(year, month)
 
 public fun YearMonth.plus(months: Int): YearMonth {
-    val monthDelta = month.ordinal + months
-    val yearDelta = if (monthDelta < 0) {
-        (monthDelta / allMonths.size) - 1
-    } else {
-        (monthDelta / allMonths.size)
-    }
-    return copy(
-        year = (yearDelta + year),
-        month = month.plusMonths(months)
-    )
+    val localDate = LocalDate(year, month, 1)
+    return localDate.plus(months, DateTimeUnit.MONTH)
+        .yearMonth
 }
 
 public fun YearMonth.until(other: YearMonth): Int {

--- a/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/datetime/YearMonthTest.kt
+++ b/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/datetime/YearMonthTest.kt
@@ -89,6 +89,11 @@ class YearMonthTest {
             2021,
             YearMonth(2022, Month.JANUARY).plus(-1).year
         )
+        // Check year of January after decrementing a while back
+        assertEquals(
+            2021,
+            YearMonth(2022, Month.JUNE).plus(-17).year
+        )
         // Check incrementing by a large number
         assertEquals(
             2030,


### PR DESCRIPTION
We now hand off to LocalDate for date calculations
Closes #109 