### PR TITLE
fix(android-views): Calendar issue when changing height dynamically

### DIFF
--- a/android-views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
+++ b/android-views/src/main/kotlin/com/boswelja/ephemeris/views/CalendarPagerAdapter.kt
@@ -33,14 +33,19 @@ internal class CalendarPagerAdapter(
 
         val colNum = getColNum(pageState)
         val rowNum = pageState.rows.size
-        return rowNum * 10 + colNum
+        return rowNum * CALENDAR_ROW_WEIGHT + colNum
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CalendarPageViewHolder {
         return CalendarPageViewHolder.create(parent).apply {
             // We create layout for a viewType in advance, it will improve performance
             // and make adjust view size dynamically possible.
-            createRows(dateBinder, itemView as ViewGroup, viewType / 10, viewType % 10)
+            createRows(
+                dateBinder = dateBinder,
+                parent = itemView as ViewGroup,
+                rowNum = viewType / CALENDAR_ROW_WEIGHT,
+                colNum = viewType % CALENDAR_ROW_WEIGHT
+            )
         }
     }
 
@@ -84,6 +89,10 @@ internal class CalendarPagerAdapter(
 
     // We assume that pageSource is providing same number of days for each row.
     private fun getColNum(pageState: CalendarPage) = if (pageState.rows.isNotEmpty()) pageState.rows[0].days.size else 0
+
+    companion object {
+        internal const val CALENDAR_ROW_WEIGHT = 10
+    }
 }
 
 internal class CalendarPageViewHolder(

--- a/android-views/src/main/kotlin/com/boswelja/ephemeris/views/pager/HeightAdjustingPager.kt
+++ b/android-views/src/main/kotlin/com/boswelja/ephemeris/views/pager/HeightAdjustingPager.kt
@@ -91,10 +91,16 @@ internal class HeightAdjustingPager @JvmOverloads constructor(
         }
 
         // Measure the child
-        val newHeight = viewHolder.itemView.measureForUnboundedHeight()
+        val childHeight = viewHolder.itemView.measureForUnboundedHeight()
 
-        // Apply the new height
-        setHeight(newHeight)
+        // If child height is higher than parent, set child height to its layout params to make sure
+        // it will invalidate properly and not cut
+        if (childHeight > measuredHeight) {
+            viewHolder.itemView.setHeight(childHeight)
+        }
+
+        // Update parent height according to child height
+        setHeight(childHeight)
     }
 
     /**

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,6 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
-    implementation("com.android.library:com.android.library.gradle.plugin:7.4.0-alpha03")
+    implementation("com.android.library:com.android.library.gradle.plugin:7.4.0-alpha06")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.6.21")
 }

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSource.kt
@@ -54,7 +54,9 @@ public class CalendarWeekPageSource(
         val daysUntil = startDate.daysUntil(date)
         // We need to account for the previous page not being 6 dates away from the start
         return if (daysUntil < 0) {
-            (daysUntil / daysInWeek) - 1
+            // If there is remainder，add a pageOffset 1
+            val pageOffset = if (daysUntil % daysInWeek != 0) 1 else 0
+            (daysUntil / daysInWeek) - pageOffset
         } else {
             daysUntil / daysInWeek
         }

--- a/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSourceTest.kt
+++ b/core/src/commonTest/kotlin/com/boswelja/ephemeris/core/data/CalendarWeekPageSourceTest.kt
@@ -137,6 +137,14 @@ class CalendarWeekPageSourceTest {
             source.getPageFor(LocalDate(2022, Month.MARCH, 20))
         )
         assertEquals(
+            -2,
+            source.getPageFor(LocalDate(2022, Month.MARCH, 13))
+        )
+        assertEquals(
+            -1,
+            source.getPageFor(LocalDate(2022, Month.MARCH, 14))
+        )
+        assertEquals(
             -13,
             source.getPageFor(LocalDate(2021, Month.DECEMBER, 22))
         )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 03 19:57:37 NZDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Create calendar page in onCreateViewHolder instead of onBindViewHolder to improve list performance
- Use viewTypes for different month types, which will allow us the change month page's height dynamically.

Credits to @nathan-git