### PR TITLE
fix(android-views): Fix a memory leak when the View is removed

### DIFF
--- a/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -34,7 +34,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     private var internalPaddingRight: Int = 0
     private var internalClipToPadding: Boolean = false
 
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private var coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val currentPager: HeightAdjustingPager?
         get() = getChildAt(0) as? HeightAdjustingPager
@@ -82,7 +82,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
         set(value) {
             @Suppress("UNCHECKED_CAST")
             _dateBinder = value as CalendarDateBinder<RecyclerView.ViewHolder>
-            if (_dateBinder != null && _pageLoader != null) {
+            if (_pageLoader != null) {
                 calendarAdapter = CalendarPagerAdapter(_pageLoader!!, _dateBinder!!)
                 initView()
             }
@@ -99,7 +99,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
                 coroutineScope,
                 value
             )
-            if (_dateBinder != null && _pageLoader != null) {
+            if (_dateBinder != null) {
                 calendarAdapter = CalendarPagerAdapter(_pageLoader!!, _dateBinder!!)
                 initView()
             }

--- a/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -11,6 +11,8 @@ import com.boswelja.ephemeris.core.ui.CalendarPageLoader
 import com.boswelja.ephemeris.views.pager.HeightAdjustingPager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.datetime.LocalDate
 
 /**
@@ -32,7 +34,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     private var internalPaddingRight: Int = 0
     private var internalClipToPadding: Boolean = false
 
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val currentPager: HeightAdjustingPager?
         get() = getChildAt(0) as? HeightAdjustingPager
@@ -123,6 +125,16 @@ public class EphemerisCalendarView @JvmOverloads constructor(
             LAYOUT_DIRECTION_RTL -> setPadding(end, top, start, bottom)
             else -> setPadding(start, top, end, bottom)
         }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        // TODO Move start logic to here
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        coroutineScope.cancel()
     }
 
     override fun getPaddingStart(): Int {


### PR DESCRIPTION
EphemerisCalendarView creates it's own CoroutineScope, but it wasn't cancelling it
Known issue: detach/attach operations are not valid. This will be fixed in a future PR