### PR TITLE
Don't launch a new scope for preloading data

### DIFF
--- a/android-compose/src/main/kotlin/com/boswelja/ephemeris/compose/EphemerisCalendar.kt
+++ b/android-compose/src/main/kotlin/com/boswelja/ephemeris/compose/EphemerisCalendar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.boswelja.ephemeris.core.data.CalendarPageSource
 import com.boswelja.ephemeris.core.model.CalendarDay
@@ -36,9 +35,8 @@ public fun EphemerisCalendar(
     contentPadding: PaddingValues = PaddingValues(),
     dayContent: @Composable BoxScope.(CalendarDay) -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val pageLoader = remember(coroutineScope, pageSource) {
-        CalendarPageLoader(coroutineScope, pageSource)
+    val pageLoader = remember(pageSource) {
+        CalendarPageLoader(pageSource)
     }
 
     // Pass page source changes on to the calendar state

--- a/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
+++ b/android-views/src/main/kotlin/com/boswelja/ephemeris/views/EphemerisCalendarView.kt
@@ -9,10 +9,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.boswelja.ephemeris.core.data.CalendarPageSource
 import com.boswelja.ephemeris.core.ui.CalendarPageLoader
 import com.boswelja.ephemeris.views.pager.HeightAdjustingPager
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.datetime.LocalDate
 
 /**
@@ -33,8 +29,6 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     private var internalPaddingLeft: Int = 0
     private var internalPaddingRight: Int = 0
     private var internalClipToPadding: Boolean = false
-
-    private var coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     private val currentPager: HeightAdjustingPager?
         get() = getChildAt(0) as? HeightAdjustingPager
@@ -95,10 +89,7 @@ public class EphemerisCalendarView @JvmOverloads constructor(
     public var pageSource: CalendarPageSource
         get() = checkNotNull(_pageLoader?.calendarPageSource) { MissingPageSourceException }
         set(value) {
-            _pageLoader = CalendarPageLoader(
-                coroutineScope,
-                value
-            )
+            _pageLoader = CalendarPageLoader(value)
             if (_dateBinder != null) {
                 calendarAdapter = CalendarPagerAdapter(_pageLoader!!, _dateBinder!!)
                 initView()
@@ -125,16 +116,6 @@ public class EphemerisCalendarView @JvmOverloads constructor(
             LAYOUT_DIRECTION_RTL -> setPadding(end, top, start, bottom)
             else -> setPadding(start, top, end, bottom)
         }
-    }
-
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
-        // TODO Move start logic to here
-    }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        coroutineScope.cancel()
     }
 
     override fun getPaddingStart(): Int {

--- a/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/ui/CalendarPageLoader.kt
+++ b/core/src/commonMain/kotlin/com/boswelja/ephemeris/core/ui/CalendarPageLoader.kt
@@ -2,91 +2,24 @@ package com.boswelja.ephemeris.core.ui
 
 import com.boswelja.ephemeris.core.data.CalendarPageSource
 import com.boswelja.ephemeris.core.model.CalendarPage
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
-import kotlin.math.abs
 
 /**
  * Handles loading data from [CalendarPageSource], caching and prefetching entries. Platform UIs
  * should make use of this class for their data loading. If the page source or focus mode change, it
- * is expected a new instance will be created and the existing instance discarded. Prefetch and
- * cache operations are handled asynchronously via [coroutineScope].
+ * is expected a new instance will be created and the existing instance discarded.
  */
 public class CalendarPageLoader(
-    private val coroutineScope: CoroutineScope,
     public val calendarPageSource: CalendarPageSource
 ) {
     private val pageCache = mutableMapOf<Int, CalendarPage>()
-
-    private val lastLoadedPage = MutableStateFlow(0)
-
-    init {
-        // Launch the page cache job
-        coroutineScope.launch {
-            lastLoadedPage
-                .collect {
-                    if (tryBuildCache(it)) {
-                        trimCache(it)
-                    }
-                }
-        }
-    }
-
-    /**
-     * Loads [CHUNK_SIZE] pages into the cache from the given page [fromPage]. If [reverse] is true,
-     * a chunk will be loaded behind the given page. Note that [fromPage] is excluded when caching.
-     */
-    private fun cacheChunk(fromPage: Int, reverse: Boolean) {
-        // Iterate from the given page to the chunk size
-        val range = if (reverse) {
-            (fromPage - CHUNK_SIZE) until fromPage
-        } else {
-            (fromPage + 1)..(fromPage + CHUNK_SIZE)
-        }
-        range.forEach { page ->
-            pageCache[page] = calendarPageSource.loadPageData(page)
-        }
-    }
-
-    /**
-     * Builds additional cache based around the given page if necessary.
-     * @return true if cache was built on, false otherwise.
-     */
-    private fun tryBuildCache(page: Int): Boolean {
-        val cacheForward = pageCache[page + PREFETCH_DISTANCE] == null
-        val cacheBackward = pageCache[page - PREFETCH_DISTANCE] == null
-        if (cacheForward) {
-            cacheChunk(page, false)
-        }
-        if (cacheBackward) {
-            cacheChunk(page, true)
-        }
-        return cacheForward || cacheBackward
-    }
-
-    /**
-     * If the cache size is growing too large, trim the furthest elements from the given page.
-     */
-    private fun trimCache(page: Int) {
-        if (pageCache.size > UPPER_CACHE_LIMIT) {
-            val maxDistance = UPPER_CACHE_LIMIT / 2
-            pageCache.keys
-                .filter { abs(page - it) > maxDistance }
-                .forEach {
-                    pageCache.remove(it)
-                }
-        }
-    }
 
     /**
      * Gets the data to display for the given page. If necessary, a cache load operation will be
      * started to ensure there's enough data available ahead of time.
      */
     public fun getPageData(page: Int): CalendarPage {
-        lastLoadedPage.tryEmit(page)
-        return pageCache[page] ?: calendarPageSource.loadPageData(page)
+        return pageCache.getOrPut(page) { calendarPageSource.loadPageData(page) }
     }
 
     /**
@@ -94,7 +27,6 @@ public class CalendarPageLoader(
      * given page, falls back to the full range of dates displayed.
      */
     public fun getDateRangeFor(page: Int): ClosedRange<LocalDate> {
-        // Cast to non-null here since in theory a page has already been loaded
         val pageData = getPageData(page)
         val startDate = pageData.rows.first().days.firstOrDefault { it.isFocusedDate }.date
         val endDate = pageData.rows.last().days.lastOrDefault { it.isFocusedDate }.date
@@ -115,11 +47,5 @@ public class CalendarPageLoader(
      */
     private fun <T> List<T>.lastOrDefault(predicate: (T) -> Boolean): T {
         return lastOrNull(predicate) ?: last()
-    }
-
-    public companion object {
-        private const val PREFETCH_DISTANCE = 5
-        private const val CHUNK_SIZE = 20
-        private const val UPPER_CACHE_LIMIT = 250
     }
 }


### PR DESCRIPTION
Local testing revealed there is no significant difference in performance here, since calculating pages is not exactly a heavy task